### PR TITLE
coursehub: roster print styles

### DIFF
--- a/src/scss/_print.scss
+++ b/src/scss/_print.scss
@@ -1,0 +1,33 @@
+@media print {
+  img {
+    break-inside: avoid;
+  }
+
+  .print-hide {
+    display: none !important;
+  }
+
+  .roster-page {
+    .midd-footer,
+    .breadcrumb,
+    .app-header {
+      display: none !important;
+    }
+
+    .page-header__content {
+      padding: 0 !important;
+    }
+
+    // Forces all rows on the roster page to be block instead of flex.
+    // Otherwise break-inside won't work in chrome with ANY parent as display: flex.
+    .main .row {
+      display: block;
+    }
+
+    .main [class*='col-'] {
+      width: 100%;
+      flex-basis: 100%;
+      max-width: 100%;
+    }
+  }
+}

--- a/src/scss/components/_roster.scss
+++ b/src/scss/components/_roster.scss
@@ -1,0 +1,10 @@
+.roster {
+  @include clearfix;
+  @include make-negative-gutters;
+}
+
+.roster__item {
+  @include make-gutters;
+  float: left;
+  width: 50%;
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -14,6 +14,7 @@
 // base
 @import 'global';
 @import 'keyframes';
+@import 'print';
 
 // components
 @import 'components/accordion';
@@ -71,6 +72,7 @@
 @import 'components/pagination';
 @import 'components/profile-spotlight-item';
 @import 'components/quote';
+@import 'components/roster';
 @import 'components/schedule';
 @import 'components/school-explorer';
 @import 'components/school-footer';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -105,7 +105,6 @@
 @import 'utils/float';
 @import 'utils/hover';
 @import 'utils/order';
-@import 'utils/page-break';
 @import 'utils/screen-reader';
 @import 'utils/sizing';
 @import 'utils/spacing';

--- a/src/scss/utils/_page-break.scss
+++ b/src/scss/utils/_page-break.scss
@@ -1,3 +1,0 @@
-.page-break-inside-avoid {
-  page-break-inside: avoid;
-}

--- a/src/templates/course-hub-roster.twig
+++ b/src/templates/course-hub-roster.twig
@@ -1,5 +1,7 @@
 {% extends "course-hub-layout.twig" %}
 
+{% set body_class = 'roster-page' %}
+
 {% set page_header = {
   title: 'Roster for AMST 0210A',
   breadcrumb: [
@@ -13,35 +15,41 @@
 } %}
 
 {% block nav %}
-  {% include 'partials/page-nav.twig' with {
-    label: 'My Terms',
-    items: [
-      {text: 'Fall 2019'},
-      {text: 'Fall 2019'},
-      {text: 'Fall 2019'},
-      {text: 'Fall 2019'},
-      {text: 'Fall 2019'},
-    ]
-  } %}
+  <div class="print-hide">
+    {% include 'partials/page-nav.twig' with {
+      label: 'My Terms',
+      items: [
+        {text: 'Fall 2019'},
+        {text: 'Fall 2019'},
+        {text: 'Fall 2019'},
+        {text: 'Fall 2019'},
+        {text: 'Fall 2019'},
+      ]
+    } %}
+  </div>
 {% endblock %}
 {% block sidebar %}
 
-  {% include 'partials/course-hub-sidebar.twig' %}
+  <div class="print-hide">
+    {% include 'partials/course-hub-sidebar.twig' %}
+  </div>
 
 {% endblock %}
 
 {% block content %}
 
-  {% include 'partials/course-hub-tabs.twig' with { active: 4 } %}
+  <div class="print-hide">
+    {% include 'partials/course-hub-tabs.twig' with { active: 4 } %}
+  </div>
 
-  <div class="row">
+  <div class="roster">
 
     {% for n in 0..3 %}
 
-      <div class="col-sm-6">
+      <div class="roster__item">
 
         {% include 'partials/coursehub-profile.twig' with {
-          name: 'Connell, James Holland (Jimmy)',
+          name: 'Some longer name here goes on and on Connell, James Holland (Jimmy)',
           meta: [
             { name: 'Email', value: 'jconnell@middlebury.edu', href: '#' },
             { name: 'Advisor', value: 'Rachael Joo', href: '#' },

--- a/src/templates/partials/coursehub-profile.twig
+++ b/src/templates/partials/coursehub-profile.twig
@@ -1,4 +1,4 @@
-<div class="mb-4 mb-md-7 page-break-inside-avoid">
+<div class="mb-4 mb-md-7">
   <div class="mb-3">
     <a href="#">
       {% include 'partials/img.twig' with {
@@ -28,7 +28,7 @@
   </dl>
 
   {% if actions %}
-    <div class="mt-4">
+    <div class="mt-4 print-hide">
       {% for action in actions %}
         <a href="{{action.href}}" class="f2 link-underline">{{action.label}}</a>
       {% endfor %}

--- a/src/templates/partials/grid-overlay.twig
+++ b/src/templates/partials/grid-overlay.twig
@@ -1,6 +1,12 @@
 <div>
 <!-- do not include in production -->
 <style>
+  @print {
+    [class*='debug-grid'] {
+      display: none !important;
+    }
+  }
+
   .debug-grid-center {
     display: block;
     position: fixed;

--- a/src/templates/partials/profile-teaser.twig
+++ b/src/templates/partials/profile-teaser.twig
@@ -1,4 +1,4 @@
-<div class="media-object mb-4 mb-sm-5 md-md-7 page-break-inside-avoid">
+<div class="media-object mb-4 mb-sm-5 md-md-7">
   <div class="media-object__image">
     <a href="#">
       {% include 'partials/img.twig' with {


### PR DESCRIPTION
This requires a body class of `roster-page` if possible. I'm scoping these print styles to mainly the roster page as I don't want to affect all of our sites just yet until we have a better plan for print styles. 