### PR TITLE
add lite variation of school footer for menuless version

### DIFF
--- a/src/scss/components/_footer-menu.scss
+++ b/src/scss/components/_footer-menu.scss
@@ -1,5 +1,5 @@
 .footer-menu {
-  margin-top: $spacing-7;
+  margin-top: $spacing-5;
   @include media(lg) {
     margin-top: 0;
   }

--- a/src/scss/components/_school-footer.scss
+++ b/src/scss/components/_school-footer.scss
@@ -10,21 +10,82 @@
 }
 
 .school-footer__main {
-  border-bottom: 1px solid $navy-light;
+  @include make-col-ready;
 
   @include media(lg) {
-    border-right: 1px solid $navy-light;
-    border-bottom: 0;
+    @include make-col(4);
   }
 }
 
-.school-footer__name {
+.school-footer__primary {
+  @include make-col-ready;
+
+  @include media(md) {
+    @include make-col(5);
+  }
+
+  @include media(lg) {
+    @include make-col(12);
+  }
+
+  .school-footer--lite & {
+    @include media(lg) {
+      @include make-col(5);
+    }
+  }
+}
+
+.school-footer__secondary {
+  @include make-col-ready;
+  padding-top: $spacing-5;
+  padding-bottom: $spacing-5;
+
+  @include media(md) {
+    @include make-col(4);
+    margin-left: auto;
+  }
+
+  @include media(lg) {
+    @include make-col(12);
+    padding-bottom: 0;
+  }
+
+  .school-footer--lite & {
+    padding-bottom: 0;
+    @include media(md) {
+      border-left: 1px solid $navy-light;
+      padding-top: $spacing-3;
+      padding-bottom: $spacing-3;
+    }
+
+    @include media(lg) {
+      @include make-col(4);
+    }
+  }
+}
+
+.school-footer__text {
   @include h0;
-  font-family: $font-family-serif;
   color: $white;
   margin-bottom: $spacing-4;
 
   @include media(md) {
     margin-bottom: $spacing-5;
+  }
+}
+
+.school-footer__nav {
+  @include make-col-ready;
+  border-top: 1px solid $navy-light;
+
+  @include media(md) {
+    margin-top: $spacing-5;
+  }
+
+  @include media(lg) {
+    @include make-col(8);
+    border-left: 1px solid $navy-light;
+    border-top: 0;
+    margin-top: 0;
   }
 }

--- a/src/templates/partials/school-footer.twig
+++ b/src/templates/partials/school-footer.twig
@@ -1,16 +1,21 @@
-<footer class="school-footer">
+{% set has_menus = menus is not empty %}
+<footer class="school-footer{% if not has_menus %} school-footer--lite{% endif %}">
   <div class="container">
-    <div class="row">
-      <div class="col-lg-4 school-footer__main">
+    {% if has_menus %}
+      <div class="row">
+        <div class="school-footer__main">
+    {% endif %}
 
         <div class="row">
-          <div class="col-md-8 col-lg-12 mb-7">
+          <div class="school-footer__primary">
 
-            <p class="school-footer__name">{{name}}</p>
+            {# use same markup for slogan #}
+            <p class="school-footer__text">{{name}}</p>
+
             <a href="{{cta.link}}" class="button button--light">{{cta.text}}</a>
 
           </div>
-          <div class="col-md-4 col-lg-12 mb-7">
+          <div class="school-footer__secondary">
 
             <div class="text-white f2 mb-3">
               <p class="mb-1 f2">{{addr}}</p>
@@ -25,15 +30,19 @@
 
           </div>
 
+      {% if has_menus %}
         </div>
       </div>
-      <div class="col-lg-8">
-        <div class="row">
-          {% for menu in menus %}
-            {% include 'partials/footer-menu.twig' with menu %}
-          {% endfor %}
+      {% endif %}
+      {% if has_menus %}
+        <div class="school-footer__nav">
+          <div class="row">
+            {% for menu in menus %}
+              {% include 'partials/footer-menu.twig' with menu %}
+            {% endfor %}
+          </div>
         </div>
-      </div>
+      {% endif %}
     </div>
   </div>
 </footer>

--- a/src/templates/school-home-blse.twig
+++ b/src/templates/school-home-blse.twig
@@ -29,3 +29,17 @@
   {% include 'paragraphs/button-box.twig' %}
 
 {% endblock %}
+
+{% block layout_footer %}
+  {% include 'partials/school-footer.twig' with {
+    name: 'Middlebury Bread Loaf School of English',
+    addr: '356 College Street<br>Middlebury, VT 05753',
+    tel: '802-443-5745',
+    email: 'blse@middlebury.edu',
+    cta: {
+      text: 'Request Info',
+      link: 'http://go.middlebury.edu/sa-inquiry'
+    },
+  } %}
+  {% include 'partials/midd-footer.twig' %}
+{% endblock %}


### PR DESCRIPTION
Since BLSE has no footer menus (which could certainly change), I've set up the school-footer per Ari's design to adjust layout when menus is empty. If the logic should be controlled by some other means, let me know. This seemed like a decent approach. 
