### PR TITLE
Rework page-nav mobile presentation

### DIFF
--- a/src/scss/components/_page-nav.scss
+++ b/src/scss/components/_page-nav.scss
@@ -1,25 +1,37 @@
 .page-nav {
   margin-bottom: $spacing-4;
+  border: 1px solid $border-color;
+
   @include breakpoint(md) {
     margin-bottom: $spacing-8;
   }
+
+  @include breakpoint(lg) {
+    border: 0;
+  }
+
   @include print-hide;
 }
 
+.page-nav__header {
+  display: flex;
+}
+
 .page-nav__title {
-  border-bottom: 4px solid $border-color;
   @include small-caps;
+  flex: 1 1 auto;
+
+  @include breakpoint(lg) {
+    border-bottom: 4px solid $border-color;
+  }
 }
 
 .page-nav__button {
-  padding: 1rem;
-  border: 1px solid $border-color;
-  width: 100%;
-  background: none;
+  flex: 0 0 auto;
+  padding: $input-btn-padding-x-sm;
+  border-left: 1px solid $border-color;
   font-size: $typescale-2;
   font-weight: $font-weight-semibold;
-  // font-family: inherit;
-  text-align: left;
   color: $color-primary;
 
   @include breakpoint(lg) {
@@ -27,20 +39,7 @@
   }
 }
 
-.page-nav__icon {
-  float: right;
-  transition: $chevron-transition;
-
-  .page-nav__button.is-toggled & {
-    transform: $chevron-transform;
-  }
-}
-
 .page-nav__content {
-  padding-left: 1rem;
-  padding-right: 1rem;
-  border: 1px solid $border-color;
-  border-top: 0;
   background-color: #f2f2f2;
 
   @include breakpoint(lg) {
@@ -79,8 +78,15 @@
 
 .page-nav__link {
   display: block;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-top: $spacing-3;
+  padding-bottom: $spacing-3;
+  padding-left: $spacing-3;
+  padding-right: $spacing-3;
+
+  @include breakpoint(lg) {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .page-nav__link--active {

--- a/src/scss/components/_page-nav.scss
+++ b/src/scss/components/_page-nav.scss
@@ -33,6 +33,7 @@
   font-size: $typescale-2;
   font-weight: $font-weight-semibold;
   color: $color-primary;
+  line-height: 1;
 
   @include breakpoint(lg) {
     display: none;

--- a/src/templates/partials/page-nav.twig
+++ b/src/templates/partials/page-nav.twig
@@ -14,20 +14,29 @@
 {% import _self as macros %}
 
 <nav class="page-nav" aria-labelledby="midd-page-nav-label">
-  <button
-    class="page-nav__button"
-    data-toggle-target=".js-page-nav"
-    aria-haspopup="true"
-    aria-expanded="false"
-  >
-    Additional Navigation
-    {% include 'partials/icon.twig' with { name: 'chevron-down', class: 'page-nav__icon' } %}
-  </button>
-  <div class="page-nav__content js-page-nav">
+  <div class="page-nav__header">
     <h2 class="page-nav__title" id="midd-page-nav-label">
       <a href="{{href}}" class="page-nav__link">{{label|default("Lorem ipsum")}}</a>
     </h2>
+    <button
+      class="page-nav__button"
+      data-toggle-target=".js-page-nav"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      <span class="sr-only">Toggle {{label}} Navigation</span>
+      {% include 'partials/icon.twig' with {
+        name: 'bars',
+        class: 'toggled-hide'
+      } %}
+      {% include 'partials/icon.twig' with {
+        name: 'times',
+        class: 'toggled-show'
+      } %}
 
+    </button>
+  </div>
+  <div class="page-nav__content js-page-nav">
     {{ macros.list(items) }}
   </div>
 </nav>

--- a/src/templates/school-basic-content.twig
+++ b/src/templates/school-basic-content.twig
@@ -1,50 +1,62 @@
-{% extends "school-layout.twig" %}
+{% extends 'school-layout.twig' %}
 
 {% set page_header = {
   title: 'School basic content',
   breadcrumb: [
-    { text: 'Offices and Services' },
-    { text: 'Student Financial Services' },
+    {
+      text: 'Offices and Services'
+    },
+    {
+      text: 'Student Financial Services'
+    }
   ]
 } %}
 
 {% block page %}
   {% embed 'partials/sidebar-layout.twig' %}
     {% block nav %}
-
       {% include 'partials/page-nav.twig' with {
         label: 'Student Financial Services',
         items: [
-          { text: 'Curriculum', href: '#' },
+          {
+            text: 'Curriculum',
+            href: '#'
+          },
           {
             text: 'Faculty',
             href: '#',
             items: [
-              { text: 'Faculty sub page 1', href: '#' },
-              { text: 'Faculty sub page 2', href: '#' },
+              {
+                text: 'Faculty sub page 1',
+                href: '#'
+              },
+              {
+                text: 'Faculty sub page 2',
+                href: '#'
+              },
               {
                 text: 'Faculty sub page 3',
                 href: '#',
                 active: true
               },
-              { text: 'Faculty sub page 4', href: '#' },
+              {
+                text: 'Faculty sub page 4',
+                href: '#'
+              }
             ]
           },
-          { text: 'Financing Your Education', href: '#' },
+          {
+            text: 'Financing Your Education',
+            href: '#'
+          }
         ]
       } %}
-
     {% endblock %}
     {% block toc %}
-
       <div data-digest-nav data-sticky data-sticky-offset=".js-headroom"></div>
-
     {% endblock %}
     {% block content %}
-
       {% include 'partials/basic-content.twig' %}
-
     {% endblock %}
   {% endembed %}
 {% endblock %}
-


### PR DESCRIPTION
We'd like to slightly change how the mobile page-nav is presented in hopes of achieving a few things
- Aligns the pattern with our other mobile menus like the school drawer nav and now the office/anchor nav that has dropdowns
- Changes toggle button icon from chevron to bars/menu icon to further clarify the element as a menu/nav
- Replaces "Additional Navigation" vague label with the 1st item / section-you-are-in label

@imcbride can you investigate what it'd take to make this changes on production and if there are any complications with this proposal? Per [my slack message](https://middlebury.slack.com/archives/G1KKMK4KF/p1585859962080400) about this, I was concerned we may have menus floating around that this would not work on if they do not have the "section" label (capitalized text at the top of page-nav). If we _do_ have any of those, we'll need a default label and to consider not rendering the label as a link. 