### PR TITLE
Use window.location.assign() instead of window.history.pushState() to…

### DIFF
--- a/src/js/select-url.ts
+++ b/src/js/select-url.ts
@@ -42,7 +42,7 @@ function createUrlSelector(elem: HTMLElement) {
       return;
     }
 
-    window.history.pushState(null, '', select.value);
+    window.location.assign(select.value);
   }
 
   on(elem, 'click', handleElemClick);


### PR DESCRIPTION
… avoid exceptions on the library guides tab. For #351.