### PR TITLE
Add styles for embedded Slate forms. For #376.

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -106,6 +106,7 @@
 @import 'scope/typography';
 @import 'scope/google-custom-search';
 @import 'scope/webform';
+@import 'scope/slateform';
 
 // utils
 @import 'utils/background';

--- a/src/scss/scope/_slateform.scss
+++ b/src/scss/scope/_slateform.scss
@@ -1,0 +1,82 @@
+.slateform {
+  padding: 2px;
+
+  a {
+    @include link-border;
+  }
+
+  h1 {
+    @include h3;
+    margin-bottom: $spacing-4;
+  }
+
+  fieldset {
+    @include form-fieldset;
+
+    div:last-of-type {
+      margin-bottom: 0;
+    }
+
+    > .form_label {
+      display: none;
+    }
+  }
+
+  legend {
+    @include form-legend;
+  }
+
+  .action,
+  .form_question,
+  fieldset > div {
+    @include form-group;
+  }
+
+  label,
+  .form_label {
+    @include form-label;
+  }
+
+  div[data-required='1'] label:after {
+    content: ' *';
+    @include form-required;
+  }
+
+  select,
+  textarea,
+  input[type='text'],
+  input[type='email'],
+  input[type='tel'] {
+    @include form-control;
+    margin-top: 0; // remove style coming from global form-text, which is meant for helper text
+    padding: $spacing-2;
+    width: auto;
+    max-width: 100%;
+  }
+
+  select {
+    @include form-select;
+  }
+
+  .action button {
+    @include button-base;
+    @include button-theme('primary');
+  }
+
+  .form_responses {
+    @include breakpoint(sm) {
+      display: flex;
+    }
+
+    select, input {
+      @include breakpoint(sm) {
+        flex: 0 0 auto;
+        margin-bottom: 0;
+      }
+
+      &:not(:last-child) {
+        margin-right: $spacing-3;
+      }
+    }
+  }
+}

--- a/src/templates/webforms-slate.twig
+++ b/src/templates/webforms-slate.twig
@@ -1,0 +1,67 @@
+{% extends "anchor-basic-content.twig" %}
+
+{% block page %}
+  {% embed 'partials/sidebar-layout.twig' %}
+    {% block nav %}
+      {% include 'partials/page-nav.twig' with {
+        items: [
+          {
+            text: 'Curriculum',
+            href: '#'
+          },
+          {
+            text: 'Faculty',
+            href: '#',
+            items: [
+              {
+                text: 'Faculty sub page 1',
+                href: '#'
+              },
+              {
+                text: 'Faculty sub page 2',
+                href: '#'
+              },
+              {
+                text: 'Faculty sub page 3',
+                href: '#'
+              },
+              {
+                text: 'Faculty sub page 4',
+                href: '#'
+              }
+            ]
+          },
+          {
+            text: 'Financing Your Education',
+            href: '#'
+          }
+        ]
+      } %}
+    {% endblock %}
+    {% block toc %}
+      <div data-digest-nav data-sticky data-sticky-offset=".js-headroom"></div>
+    {% endblock %}
+    {% block sidebar %}
+      <div class="bg-gray-lighter mb-md-6 p-3">
+        <div class="row">
+          <div class="col-12 col-md-6 col-lg-12 order-md-2 order-lg-1">
+            {% include 'partials/page-cta.twig' %}
+            <div class="border-b my-6 d-md-none d-lg-block"></div>
+          </div>
+          <div class="col-12 col-md-6 col-lg-12 order-md-1 order-lg-2">
+            {% include 'partials/office-meta.twig' %}
+          </div>
+        </div>
+      </div>
+    {% endblock %}
+    {% block content %}
+<div id="form_08c8914d-d97e-43e2-bfac-4857a0080098" class="slateform">Loading...</div><script>/*<![CDATA[*/var script = document.createElement('script'); script.async = 1; script.src = 'https://admissions.middlebury.edu/register/?id=08c8914d-d97e-43e2-bfac-4857a0080098&amp;output=embed&amp;div=form_08c8914d-d97e-43e2-bfac-4857a0080098' + ((location.search.length > 1) ? '&' + location.search.substring(1) : ''); var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(script, s); script.addEventListener('load', function() { var checkExist = setInterval(function() {
+  var links = document.querySelectorAll('link[href*="technolutions.net"]');
+  [].forEach.call(links, function(link) {
+    link.disabled = "true";
+  });
+  clearInterval(checkExist);
+}, 100); }); /*]]>*/</script>
+    {% endblock %}
+  {% endembed %}
+{% endblock %}


### PR DESCRIPTION
This PR adds the styles necessary for the one existing embedded Slate form, which is at https://www.middlebury.edu/office/middcore/who-we-are/contact-us. There are probably some improvements which could be made here and the styles will need to be extended to incorporate other form elements as they are used in other forms (notably there are no checkbox or radio button styles here), but we should wait until we have a real example form to work off of for those.