### PR TITLE
Accordion link issue #457

### DIFF
--- a/src/js/accordion.ts
+++ b/src/js/accordion.ts
@@ -1,0 +1,7 @@
+import { $ } from './utils/dom';
+
+// Adds functionality for toggling accordion item if it's link is openend 
+// in new tab or window, by checking if it's ID exists in the URL
+if(location.hash.includes('#midd-accordion-item-label')) {
+  $(location.hash.replace('#midd-accordion-item-label', '.js-accordion-item')).classList.add('is-toggled');
+}

--- a/src/js/accordion.ts
+++ b/src/js/accordion.ts
@@ -3,5 +3,5 @@ import { $ } from './utils/dom';
 // Adds functionality for toggling accordion item if it's link is openend 
 // in new tab or window, by checking if it's ID exists in the URL
 if(location.hash.includes('#midd-accordion-item-label')) {
-  $(location.hash.replace('#midd-accordion-item-label', '.js-accordion-item')).classList.add('is-toggled');
+  $(location.hash.replace('#midd-accordion-item-label', '.js-accordion-item'))?.classList.add('is-toggled');
 }

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -42,6 +42,7 @@ import './events-datepicker'; // make the events datepicker accessible
 import './audio-player'; // custom Preact audio player
 import './offices'; // middlebury.edu/office homepage script for filtering items shown
 import './mover'; // mover util for moving an element from one element to another at a breakpoint. Doesn't work if event listeners are on any of the elements that are moved.TODO: remove me and use css-grid to move layout around
+import './accordion';
 import './lightbox';
 import './card-carousel';
 import './dropdown';

--- a/src/templates/partials/accordion.twig
+++ b/src/templates/partials/accordion.twig
@@ -8,7 +8,7 @@
     <div class="accordion-item js-accordion-item-{{id}}{{ item.current ? " accordion-item-current" : "" }}{{ item.upcoming ? " accordion-item-upcoming" : "" }}">
       <h3 class="accordion-item__title" role="tab">
         <a
-          href="#accordion-content-{{id}}"
+          href="#midd-accordion-item-label-{{id}}"
           class="accordion-item__link"
           data-toggle-target=".js-accordion-item-{{id}}"
           aria-expanded="false"


### PR DESCRIPTION
- Changed the accordion item's href to link to the title of the item rather than content.
- Added functionality for toggling accordion item if it's link is opened in new tab or window, by checking if it's ID exists in the URL.