### PR TITLE
Add a composer.json for inclusion via Composer into PHP projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "middlebury/midd-frontend",
+    "description": "Middlebury College's theme assets.",
+    "homepage": "https://github.com/middlebury/midd-frontend",
+    "type": "drupal-library",
+    "license": "GPL-2.0-or-later"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,7 +84,8 @@ const clean = () =>
     './dist/**/*.html',
     './dist/**/*.js',
     './dist/**/*.css',
-    './dist/images/*'
+    './dist/images/*',
+    './dist/*.json'
   ]);
 
 const serve = () =>
@@ -261,6 +262,14 @@ const copyDeps = () => {
     .pipe(gulp.dest('./dist/js'));
 };
 
+const copyMeta = () => {
+  return gulp
+    .src([
+      './composer.json'
+    ])
+    .pipe(gulp.dest('./dist/'));
+};
+
 const deployDist = () => {
   if (!THEME_DIR) {
     return console.error('No `--themeDir` argument passed');
@@ -356,6 +365,7 @@ const buildIconSprite = () =>
 const build = gulp.series(
   clean,
   copyDeps,
+  copyMeta,
   gulp.parallel(html, images, lintStyles, styles, scripts),
   reportFilesizes
 );


### PR DESCRIPTION
I did some research and found that we can incorporate the `master-dist` contents into Drupal (and other PHP projects) using the [Composer](https://getcomposer.org/) package manager for PHP (which we are already using heavily for Drupal). The requirement for this repository is the addition of a `composer.json` file that includes metadata about this package, which I've added in this PR.

The Drupal/PHP side:
1. By requiring this package in Drupal's `composer.json` Composer will use Git to download the contents of the master-dist branch and place it in the file-system location for the package-type (I've labeled this package as a `drupal-library` which will cause it to be placed in `drupal/web/libraries/middlebury/midd-frontend/`.
2. Reference the composer-installed files rather than copied-into-the-theme-directory files:
    a. The easiest option is that we can commit relative symbolic links that point at the new directories the `middlebury_theme` directory. E.g.:
    
       web/themes/custom/middlebury_theme/css ==> ../../libraries/middlebury/midd-frontend/css
       web/themes/custom/middlebury_theme/images ==> ../../libraries/middlebury/midd-frontend/images
       web/themes/custom/middlebury_theme/js ==> ../../libraries/middlebury/midd-frontend/js
       
    b. Optionally, we could update the [`middlebury_theme.libraries.yml`](https://github.com/middlebury/drupal/blob/main/web/themes/custom/middlebury_theme/middlebury_theme.libraries.yml) to point at this new location instead of needing the symbolic links.


Potential future work:
 * If we have the CI steps create a zip file of the build as a release, then that could be downloaded by composer instead of a `git clone` of the `master-dist` branch. This is slightly more performant and reduces the need for GitHub oauth tokens, but isn't fully necessary.